### PR TITLE
use `undefined` as the default password

### DIFF
--- a/publisher.js
+++ b/publisher.js
@@ -5,7 +5,7 @@ const settings = require('ep_etherpad-lite/node/utils/Settings');
 let HOST = '127.0.0.1';
 let PORT = 6379;
 let CHANNEL = 'from-etherpad-redis-channel';
-let PASSWORD = null;
+let PASSWORD = undefined;
 
 var areParamsOk = (settings.ep_redis_publisher) ? true : false;
 


### PR DESCRIPTION
## Problem

currently this plugin is not useable without a password, because for "falsy" passwords (`""`, `0`, `false`, `null` and `undefined`) it always defaults to `null`

```js
let PASSWORD = null;
[...]
PASSWORD = settings.ep_redis_publisher.password || PASSWORD;
```

leading to following error:

```
[2020-05-31 09:30:48.940] [ERROR] console - ReplyError: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?
    at parseError (/opt/etherpad-lite/node_modules/redis-parser/lib/parser.js:193:12)
    at parseType (/opt/etherpad-lite/node_modules/redis-parser/lib/parser.js:303:14)
```

because `node-redis` only considers `undefined` as no password.

https://github.com/NodeRedis/node-redis/blob/0041e3e53d5292b13d96ce076653c5b91b314fda/index.js#L240
```js
 if (this.auth_pass !== undefined) { 
```


## Solution
with this pull request it will use `undefined` as the fallback value instead of `null`
